### PR TITLE
variants release 0.9.4

### DIFF
--- a/Formula/variants@0.9.2.rb
+++ b/Formula/variants@0.9.2.rb
@@ -1,0 +1,12 @@
+class VariantsAT092 < Formula
+  desc "Setup deployment variants and fully working CI/CD pipelines for mobile projects"
+  homepage "https://github.com/backbase/variants.git"
+  url "https://github.com/backbase/variants.git", tag: "0.9.2"
+  version "0.9.2"
+
+  depends_on :macos
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+end

--- a/Formula/variants@0.9.3.rb
+++ b/Formula/variants@0.9.3.rb
@@ -1,0 +1,12 @@
+class VariantsAT093 < Formula
+  desc "Setup deployment variants and fully working CI/CD pipelines for mobile projects"
+  homepage "https://github.com/backbase/variants.git"
+  url "https://github.com/backbase/variants.git", tag: "0.9.3"
+  version "0.9.3"
+
+  depends_on :macos
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+end

--- a/Formula/variants@0.9.4.rb
+++ b/Formula/variants@0.9.4.rb
@@ -1,4 +1,4 @@
-class Variants < Formula
+class VariantsAT094 < Formula
   desc "Setup deployment variants and fully working CI/CD pipelines for mobile projects"
   homepage "https://github.com/backbase/variants.git"
   url "https://github.com/backbase/variants.git", tag: "0.9.4"


### PR DESCRIPTION
* Correct variants formulae for version 0.9.2 and 0.9.3
* Variants release 0.9.4

(Only merge when variants release happened, and tag `0.9.4` has been created)