### PR TITLE
classe name update for variants 1.0.0

### DIFF
--- a/Formula/variants@1.0.0.rb
+++ b/Formula/variants@1.0.0.rb
@@ -1,4 +1,4 @@
-class VariantsAT094 < Formula
+class VariantsAT100 < Formula
   desc "Setup deployment variants and fully working CI/CD pipelines for mobile projects"
   homepage "https://github.com/backbase/variants.git"
   url "https://github.com/backbase/variants.git", tag: "1.0.0"


### PR DESCRIPTION
The class name in the formula for variants 1.0.0 is wrong, changed to VariantsAT100